### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 reflex==0.7.1
+pydantic==2.10.6
+sqlmodel==0.0.24
 opencv-python==4.11.0.86
 tensorflow==2.18.0
 mediapipe


### PR DESCRIPTION
Pin pydantic/sqlmodel: reflex 0.7.1's pydantic-v1 compat shim breaks with pydantic>=2.11 (and sqlmodel>=0.0.25, which requires pydantic>=2.11).
